### PR TITLE
update bugs and thickness estimator

### DIFF
--- a/examples/NonLinearFineStructure.ipynb
+++ b/examples/NonLinearFineStructure.ipynb
@@ -703,7 +703,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/ThicknessExample.ipynb
+++ b/examples/ThicknessExample.ipynb
@@ -106,17 +106,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "14fba1ba-9aea-43f5-a25c-0c25fae74f66",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x1c021bf76d0>"
+       "<matplotlib.image.AxesImage at 0x22b3145f520>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "470b67f1-ea48-4dad-a94d-b00c170ece81",
    "metadata": {},
    "outputs": [
@@ -144,7 +144,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "16384it [00:09, 1674.92it/s]\n"
+      "16384it [00:10, 1597.99it/s]\n"
      ]
     }
    ],
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "1ab8b5f8-36fc-4b46-a890-5550b711a574",
    "metadata": {},
    "outputs": [],
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "d9040858-caf9-4263-be93-f96956e0ee77",
    "metadata": {
     "scrolled": true
@@ -191,10 +191,10 @@
     {
      "data": {
       "text/plain": [
-       "<pyEELSMODEL.operators.multispectrumvisualizer.MultiSpectrumVisualizer at 0x23c79228160>"
+       "<pyEELSMODEL.operators.multispectrumvisualizer.MultiSpectrumVisualizer at 0x22b33d8e370>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "ba3c085b-b2cc-4c8f-82c4-4a8029d2dcd7",
    "metadata": {},
    "outputs": [],
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "58606d34-8661-4f0d-acda-40f290011174",
    "metadata": {},
    "outputs": [],
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "d9fac822-e5a8-4eb4-90e2-c665b90a15ca",
    "metadata": {
     "scrolled": true
@@ -256,8 +256,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "16384it [01:04, 252.92it/s]\n",
-      "16384it [00:01, 10854.52it/s]\n"
+      "16384it [01:05, 251.96it/s]\n",
+      "16384it [00:01, 10954.32it/s]\n"
      ]
     }
    ],
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 17,
    "id": "de5be522-df19-4e3b-9c28-824f7cf2c1af",
    "metadata": {},
    "outputs": [
@@ -286,14 +286,14 @@
        "Text(0.5, 1.0, 'Gaussian model')"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "fig, ax = plt.subplots(1,3)\n",
-    "ax[0].imshow(tlamba_map, vmin=0,vmax=1.5. cmap='jet')\n",
+    "ax[0].imshow(tlambda_map, vmin=0,vmax=1.5, cmap='jet')\n",
     "ax[1].imshow(thick_mirror.tlambda,vmin=0,vmax=1.5,cmap='jet')\n",
     "ax[1].set_title('Mirrored')\n",
     "ax[2].imshow(thick_g.tlambda,vmin=0,vmax=1.5,cmap='jet')\n",
@@ -325,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/pyEELSMODEL/core/spectrum.py
+++ b/pyEELSMODEL/core/spectrum.py
@@ -599,6 +599,22 @@ class Spectrum:
         index_f = self.get_energy_index(Ef)
         self.set_exclude_region(index_i, index_f)
 
+    def set_include_region_energy(self, Ei, Ef):
+        """
+        Sets the included region using the energy.
+
+        Parameters
+        ----------
+        Ei: float
+            The starting energy of the excluded region.
+        Ef: float
+            The end energy of the excluded region.
+
+        """
+        index_i = self.get_energy_index(Ei)
+        index_f = self.get_energy_index(Ef)
+        self.set_include_region(index_i, index_f)
+
     def set_exclude_region(self, index_i, index_f):
         """
         Set a range of pixels from index_i to index_f (both inclusive) as
@@ -829,7 +845,8 @@ class Spectrum:
             co = np.argmin(np.abs(self.energy_axis - E))
             return co
 
-    def plot(self, externalplt=None, use_e_axis=True, logscale=False, **kwargs):
+    def plot(self, externalplt=None, use_e_axis=True, logscale=False,
+             **kwargs):
         """
         Plot the spectrum
 
@@ -1125,7 +1142,7 @@ class Spectrum:
 
         """
         if window is None:
-            window = [0, self.spectrum.size]
+            window = [0, self.size]
             index_type = True
 
         if index_type:

--- a/pyEELSMODEL/fitters/linear_fitter.py
+++ b/pyEELSMODEL/fitters/linear_fitter.py
@@ -150,7 +150,6 @@ class LinearFitter(Fitter):
                 A_matrix_ll[:, i] = self.A_matrix[:, i]
         return A_matrix_ll
 
-
     def calculate_y_vector(self):
         """
         Calculates the y vector for the linear least squares fitting.

--- a/pyEELSMODEL/fitters/lsqfitter.py
+++ b/pyEELSMODEL/fitters/lsqfitter.py
@@ -31,6 +31,10 @@ class LSQFitter(Fitter):
         use_bounds: bool, optional
             Bool indicating which if the boundaries of the parameters are used
             (default:False)
+        method: string
+            The optimization methods used, candiates are lm, trf and dogbox.
+            See https://docs.scipy.org/doc/scipy/reference/generated/
+            scipy.optimize.least_squares.html for more information.
 
         Returns
         -------

--- a/pyEELSMODEL/io_tools/hdf5_io.py
+++ b/pyEELSMODEL/io_tools/hdf5_io.py
@@ -26,8 +26,10 @@ def load_hspy(filename):
     f = h5py.File(filename, 'r')
     d = f['Experiments']
     params = []
+    haadf = []
     df = []
     detector_type = []
+
     for key in d.keys():
         if 'EELS Spectrum' in key:
             data = d[key]['data'][:]
@@ -44,11 +46,17 @@ def load_hspy(filename):
             stra = 'Acquisition_instrument'
             acq_time = d[key]['metadata'][stra]['TEM'].attrs['exposure']
             params.append([data, dispersion, offset, size, acq_time])
-
-        else:
+        elif 'HAADF' in key:
+            data = d[key]['data'][:]
+            haadf.append(data)
+            detector_type.append(key)
+        elif 'DF4' in key:
             data = d[key]['data'][:]
             df.append(data)
             detector_type.append(key)
-
     f.close()
-    return params, df, detector_type
+
+    if len(haadf) > 0:
+        return params, haadf, detector_type
+    elif len(df) > 0:
+        return params, df, detector_type

--- a/pyEELSMODEL/operators/estimate_thickness.py
+++ b/pyEELSMODEL/operators/estimate_thickness.py
@@ -1,8 +1,11 @@
 import logging
 import numpy as np
+import matplotlib.pyplot as plt
 
 from pyEELSMODEL.core.operator import Operator
 from pyEELSMODEL.operators.zlpremoval import ZLPRemoval
+from pyEELSMODEL.core.spectrum import Spectrum
+from pyEELSMODEL.core.multispectrum import MultiSpectrum
 
 logger = logging.getLogger(__name__)
 
@@ -19,28 +22,75 @@ class ThicknessEstimator(Operator):
     def log_ratio_method(self):
         """
         Calculates the inelastic mean free path by esitmating the zero loss
-        peak
+        peak. The estimated zlp is stored in the .zlp attribute. The inelastic
+        mean free path is stored in the .tlambda attribute
         """
         if self.model_type == 'Mirrored':
             zlpremoval = ZLPRemoval(self.spectrum, self.signal_range)
             zlpremoval.mirrored_zlp()
+            self.zlpremoval = zlpremoval
+            self.zlp = self.zlpremoval.mirror_zlp
+
+        elif self.model_type == 'Vacuum':
+            sub = self.spectrum.get_interval(self.signal_range)
+            int_vac = self.vacuum.get_interval(self.signal_range).integrate()
+            int_sub = sub.integrate()
+            fc1 = self.vacuum.data[np.newaxis, np.newaxis, :]
+            fc2 = int_sub[:, :, np.newaxis]
+            zlp_data = int_vac**(-1) * fc1 * fc2
+
+            self.zlp = MultiSpectrum.from_numpy(zlp_data,
+                                                self.spectrum.energy_axis)
+
         else:
             zlpremoval = ZLPRemoval(self.spectrum, self.signal_range,
                                     self.model_type)
             zlpremoval.fit_zlp()
-
-        self.zlpremoval = zlpremoval
-        # zlp_int = self.zlp_integral()
+            self.zlpremoval = zlpremoval
+            self.zlp = self.zlpremoval.zlp
 
         It = self.spectrum.multidata.sum(2)  # total integral
-
-        if self.model_type == 'Mirrored':
-            Izlp = zlpremoval.mirror_zlp.multidata.sum(2)  # zero loss integral
-        else:
-            # inelastic_sig = zlpremoval.inelastic.integrate((5., 2000.))
-            Izlp = zlpremoval.zlp.multidata.sum(2)  # zero loss integral
-
+        Izlp = self.zlp.multidata.sum(2)  # zero loss integral
         self.tlambda = np.log(It / Izlp)
+
+    def extract_vacuum(self, threshold, show_inelastic=True):
+        """
+        It can happen that vacuum is present and this can be used to
+        estimate the thickness. The vacuum spectrum is stored as the
+        .vacuum attribute
+
+        Parameters
+        ----------
+        threshold : 0 < float < 1
+            The number of times the spectrum needs to be upsampled
+        show_inelastic: boolean
+            Indicates whether the inelastic signal used for vacuum
+            determination is used.
+        """
+        fwhm = self.spectrum.get_numerical_fwhm()
+        print('FWHM is {} eV'.format(fwhm))
+        print('Integral for inelastic signal start at {} eV'.format(5*fwhm))
+        Ei = 3*fwhm
+        Ef = self.spectrum.energy_axis[-1]
+        inelastic = self.spectrum.integrate((Ei, Ef))
+
+        co = int(threshold * inelastic.size)
+        thres = np.sort(inelastic.flatten())[co]
+        boolean = inelastic < thres
+
+        avg = self.spectrum.multidata[boolean].mean(0)
+        s = Spectrum.from_numpy(avg, self.spectrum.energy_axis)
+        self.vacuum = s
+
+        if show_inelastic:
+            fig, ax = plt.subplots(1, 3)
+            ax[0].imshow(inelastic)
+            ax[1].imshow(boolean)
+            ax[2].plot(self.vacuum.energy_axis, self.vacuum.data,
+                       label='vacuum')
+            ax[2].plot(self.spectrum.energy_axis, self.spectrum.mean().data,
+                       label='average')
+            ax[2].legend()
 
     # def zlp_integral(self):
     #     """


### PR DESCRIPTION
- Upsampling of multispectrum is added
- Vacuum can be added or found in the thickness estimator
- Function which includes a region for fitting is added, up until now only excludes where available
- Bugfix on integral of a spectrum 
- In the elemental quantification an attribute is added to select which GOS array can be used (kohl or zhang) 