### PR TITLE
Different Padding modes for LL convolutions; Optimized kohl_core-loss calculation

### DIFF
--- a/pyEELSMODEL/components/CLedge/kohl_coreloss_edgecombined.py
+++ b/pyEELSMODEL/components/CLedge/kohl_coreloss_edgecombined.py
@@ -19,7 +19,7 @@ class KohlLossEdgeCombined(CoreLossEdge):
     """
 
     def __init__(self, specshape, A, E0, alpha, beta, element, edge, eshift=0,
-                 q_steps=100, dir_path=None):
+                 q_steps=100, dir_path=None, fast=False):
         """
 
          Parameters
@@ -56,6 +56,10 @@ class KohlLossEdgeCombined(CoreLossEdge):
          dir_path: string
              The filepath indicating where the GOS tables can be found.
              If None, the default path is used.
+
+        fast: bool
+        Use vectorized operations for the crossection calculation.
+
          Returns
          -------
          """
@@ -72,7 +76,7 @@ class KohlLossEdgeCombined(CoreLossEdge):
         if edge == 'K':
             xsectionK = KohlLossEdge(specshape, A, E0, alpha, beta, element,
                                      'K1', eshift=eshift, q_steps=q_steps,
-                                     dir_path=self.dir_path)
+                                     dir_path=self.dir_path,fast = fast)
 
             self.xsectionlist.append(xsectionK)
             super().__init__(specshape, A, E0, alpha, beta, element, 'K1',
@@ -86,7 +90,7 @@ class KohlLossEdgeCombined(CoreLossEdge):
             xsection_op = KohlLossEdge(specshape, A, E0, alpha, beta, element,
                                        start_edge,
                                        eshift=eshift, q_steps=q_steps,
-                                       dir_path=self.dir_path)
+                                       dir_path=self.dir_path,fast = fast)
             self.xsectionlist.append(xsection_op)
             for i in range(max_edge - 1):
                 try:
@@ -94,7 +98,7 @@ class KohlLossEdgeCombined(CoreLossEdge):
                     xsection = KohlLossEdge(specshape, A, E0, alpha, beta,
                                             element, next_edge,
                                             eshift=eshift, q_steps=q_steps,
-                                            dir_path=self.dir_path)
+                                            dir_path=self.dir_path,fast = fast)
                     xsection.parameters[0].couple(xsection_op.parameters[0])
                     xsection.parameters[1].couple(xsection_op.parameters[1])
                     xsection.parameters[2].couple(xsection_op.parameters[2])

--- a/pyEELSMODEL/components/MScatter/mscatterfft.py
+++ b/pyEELSMODEL/components/MScatter/mscatterfft.py
@@ -7,7 +7,7 @@ class MscatterFFT(Mscatter):
     Mutiple scattering using FFT (e.g. to concolve model with LL spectrum)
     """
 
-    def __init__(self, specshape, llspectrum, use_padding=True):
+    def __init__(self, specshape, llspectrum, use_padding=True,padding_mode_data="constant",padding_mode_llspectrum="constant"):
         """
         Parameters
         ----------
@@ -29,7 +29,8 @@ class MscatterFFT(Mscatter):
                             " fourier transform convolution.\nThis simulates"
                             " the effect of multiple scattering\nwhich is an "
                             "important effect in experimental spectra ")
-
+        self.padding_mode_data=padding_mode_data
+        self.padding_mode_llspectrum = padding_mode_llspectrum
         self.padding = llspectrum.size
         self.use_padding = use_padding
         # some cache to not recalculate fourier transfrom when not needed
@@ -61,10 +62,10 @@ class MscatterFFT(Mscatter):
         """
         pds = (self.padding, self.padding)
         # real fourier transform the model
-        fmodel = np.fft.rfft(np.pad(self.data, pad_width=pds))
+        fmodel = np.fft.rfft(np.pad(self.data, pad_width=pds,mode = self.padding_mode_data))
         if self.new_ll:
             self.llspectrum.normalise()
-            llpad = np.pad(self.llspectrum.data, pad_width=pds)
+            llpad = np.pad(self.llspectrum.data, pad_width=pds,mode = self.padding_mode_llspectrum)
             fll = np.fft.rfft(llpad)  # real fourier transform the ll spectrum
             self.fll = fll
             self.zlindex = np.argmax(llpad)

--- a/pyEELSMODEL/components/MScatter/mscatterfft.py
+++ b/pyEELSMODEL/components/MScatter/mscatterfft.py
@@ -22,6 +22,13 @@ class MscatterFFT(Mscatter):
             reducde artifacts coming from the FFT. If True, the calculations
             take longer but are more precise. (default: True)
 
+        padding_mode_data: string
+        Padding mode to use on data, see the different modes in np.pad. (Recommended: "edge")
+
+        padding_mode_llspectrum: string
+        Padding mode to use on llspectrum, see the different modes in np.pad. (Recommended: "constant")
+
+
         """
         super().__init__(specshape, llspectrum)
         self._setname("Multiple scattering (FFT)")

--- a/pyEELSMODEL/fitters/linear_fitter.py
+++ b/pyEELSMODEL/fitters/linear_fitter.py
@@ -10,6 +10,11 @@ from scipy.optimize import nnls
 from pyEELSMODEL.core.fitter import Fitter
 from pyEELSMODEL.components.MScatter.mscatter import Mscatter
 
+try:
+    import jax
+except:
+    pass
+
 
 class LinearFitter(Fitter):
     """
@@ -228,6 +233,15 @@ class LinearFitter(Fitter):
                 self.error = np.inf
             else:
                 self.error = resi[0]
+
+        elif self.method =="jax_ols":
+            coeff, resi, rank, sing = jax.numpy.linalg.lstsq(AW, yW, rcond=-1)
+            self.coeff = np.array(coeff)
+            if resi.size == 0:
+                self.error = np.inf
+            else:
+                self.error = np.array(resi[0])
+
 
         else:
             print('Fitting method is wrong')

--- a/pyEELSMODEL/fitters/linear_fitter.py
+++ b/pyEELSMODEL/fitters/linear_fitter.py
@@ -10,11 +10,6 @@ from scipy.optimize import nnls
 from pyEELSMODEL.core.fitter import Fitter
 from pyEELSMODEL.components.MScatter.mscatter import Mscatter
 
-try:
-    import jax
-except:
-    pass
-
 
 class LinearFitter(Fitter):
     """
@@ -233,14 +228,6 @@ class LinearFitter(Fitter):
                 self.error = np.inf
             else:
                 self.error = resi[0]
-
-        elif self.method =="jax_ols":
-            coeff, resi, rank, sing = jax.numpy.linalg.lstsq(AW, yW, rcond=-1)
-            self.coeff = np.array(coeff)
-            if resi.size == 0:
-                self.error = np.inf
-            else:
-                self.error = np.array(resi[0])
 
 
         else:

--- a/pyEELSMODEL/fitters/linear_fitter.py
+++ b/pyEELSMODEL/fitters/linear_fitter.py
@@ -10,6 +10,11 @@ from scipy.optimize import nnls
 from pyEELSMODEL.core.fitter import Fitter
 from pyEELSMODEL.components.MScatter.mscatter import Mscatter
 
+try:
+    import jax
+except:
+    pass
+
 
 class LinearFitter(Fitter):
     """
@@ -228,6 +233,14 @@ class LinearFitter(Fitter):
                 self.error = np.inf
             else:
                 self.error = resi[0]
+
+        elif self.method =="jax_ols":
+            coeff, resi, rank, sing = jax.numpy.linalg.lstsq(AW, yW, rcond=-1)
+            self.coeff = np.array(coeff)
+            if resi.size == 0:
+                self.error = np.inf
+            else:
+                self.error = np.array(resi[0])
 
 
         else:

--- a/pyEELSMODEL/fitters/linear_fitter.py
+++ b/pyEELSMODEL/fitters/linear_fitter.py
@@ -10,11 +10,6 @@ from scipy.optimize import nnls
 from pyEELSMODEL.core.fitter import Fitter
 from pyEELSMODEL.components.MScatter.mscatter import Mscatter
 
-try:
-    import jax
-except:
-    pass
-
 
 class LinearFitter(Fitter):
     """
@@ -233,15 +228,6 @@ class LinearFitter(Fitter):
                 self.error = np.inf
             else:
                 self.error = resi[0]
-
-        elif self.method =="jax_ols":
-            coeff, resi, rank, sing = jax.numpy.linalg.lstsq(AW, yW, rcond=-1)
-            self.coeff = np.array(coeff)
-            if resi.size == 0:
-                self.error = np.inf
-            else:
-                self.error = np.array(resi[0])
-
 
         else:
             print('Fitting method is wrong')


### PR DESCRIPTION
**Padding Modes:**

the behaviour of np.pad can be chosen separately for data and low-loss in MScatterFFT components.
The previous fixed padding mode of adding 0s sometimes creates artifacts at the beggining and end of the spectral range if the unconvolved component is not 0.


**Optimized kohl_core calculation:**

Accessible by adding setting fast=True when creating the component.
The calculation now uses numpy friendly syntax, no for loops over the elements of an array.
By my testing reproduces the values of the previous function to 1e-7% precision. 
Caculations times have gone from 30-40s to 0.3-0.4s in my system.